### PR TITLE
feat: 특정 인플루언서(influencerUuid)를 통해 경매글 리스트 조회 구현(#26)

### DIFF
--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/AuctionPostService.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/AuctionPostService.java
@@ -1,8 +1,10 @@
 package com.skyhorsemanpower.BE_AuctionPost.application;
 
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.CreateAuctionPostDto;
+import com.skyhorsemanpower.BE_AuctionPost.data.dto.InfluencerAllAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.SearchAllAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.SearchAuctionPostDto;
+import com.skyhorsemanpower.BE_AuctionPost.data.vo.InfluencerAllAuctionPostResponseVo;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.SearchAllAuctionPostResponseVo;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.SearchAuctionResponseVo;
 
@@ -12,4 +14,6 @@ public interface AuctionPostService {
     SearchAllAuctionPostResponseVo searchAllAuction(SearchAllAuctionPostDto searchAllAuctionPostDto);
 
     SearchAuctionResponseVo searchAuctionPost(SearchAuctionPostDto searchAuctionPostDto);
+
+    InfluencerAllAuctionPostResponseVo influencerAuctionPost(InfluencerAllAuctionPostDto influencerAllAuctionPostDto);
 }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/dto/InfluencerAllAuctionPostDto.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/dto/InfluencerAllAuctionPostDto.java
@@ -1,0 +1,18 @@
+package com.skyhorsemanpower.BE_AuctionPost.data.dto;
+
+import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class InfluencerAllAuctionPostDto {
+    private String influencerUuid;
+    private AuctionStateEnum auctionState;
+    private Integer page;
+    private Integer size;
+}

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/vo/InfluencerAllAuctionPostResponseVo.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/vo/InfluencerAllAuctionPostResponseVo.java
@@ -1,0 +1,25 @@
+package com.skyhorsemanpower.BE_AuctionPost.data.vo;
+
+import com.skyhorsemanpower.BE_AuctionPost.data.dto.AuctionPostDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class InfluencerAllAuctionPostResponseVo {
+    private List<AuctionPostDto> auctionPostDtos;
+    private int currentPage;
+    private boolean hasNext;
+
+    @Builder
+    public InfluencerAllAuctionPostResponseVo(List<AuctionPostDto> auctionPostDtos, int currentPage, boolean hasNext) {
+        this.auctionPostDtos = auctionPostDtos;
+        this.currentPage = currentPage;
+        this.hasNext = hasNext;
+    }
+}

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/presentation/AuctionPostController.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/presentation/AuctionPostController.java
@@ -3,9 +3,11 @@ package com.skyhorsemanpower.BE_AuctionPost.presentation;
 import com.skyhorsemanpower.BE_AuctionPost.application.AuctionPostService;
 import com.skyhorsemanpower.BE_AuctionPost.common.SuccessResponse;
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.CreateAuctionPostDto;
+import com.skyhorsemanpower.BE_AuctionPost.data.dto.InfluencerAllAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.SearchAllAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.SearchAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.CreateAuctionPostRequestVo;
+import com.skyhorsemanpower.BE_AuctionPost.data.vo.InfluencerAllAuctionPostResponseVo;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.SearchAllAuctionPostResponseVo;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.SearchAuctionResponseVo;
 import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
@@ -56,4 +58,19 @@ public class AuctionPostController {
         return new SuccessResponse<>(auctionPostService.searchAuctionPost(SearchAuctionPostDto.builder()
                         .auctionUuid(auctionUuid).build()));
     }
+
+    // 특정 인플루언서가 참여하는 경매글 조회
+    @GetMapping("/influencer/{influencerUuid}")
+    @Operation(summary = "특정 인플루언서가 참여하는 경매글 리스트 조회", description = "특정 인플루언서가 참여하는 경매글 리스트 조회")
+    public SuccessResponse<InfluencerAllAuctionPostResponseVo> influencerAuctionPost (
+            @RequestHeader String uuid,
+            @PathVariable("influencerUuid") String influencerUuid,
+            @RequestParam(required = false) AuctionStateEnum auctionState,
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size) {
+        return new SuccessResponse<>(auctionPostService.influencerAuctionPost(InfluencerAllAuctionPostDto.builder()
+                        .influencerUuid(influencerUuid)
+                .auctionState(auctionState).page(page).size(size).build()));
+    }
+
 }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/CustomReadAuctionPostRepository.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/CustomReadAuctionPostRepository.java
@@ -1,10 +1,14 @@
 package com.skyhorsemanpower.BE_AuctionPost.repository.mongotemplate;
 
+import com.skyhorsemanpower.BE_AuctionPost.data.dto.InfluencerAllAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.SearchAllAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.domain.cqrs.read.ReadAuctionPost;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomReadAuctionPostRepository {
     Page<ReadAuctionPost> findAllAuctionPost(SearchAllAuctionPostDto searchAllAuctionDto, Pageable pageable);
+
+    Page<ReadAuctionPost> findAllInfluencerAuctionPost(InfluencerAllAuctionPostDto influencerAllAuctionPostDto, Pageable pageable);
 }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/impl/CustomReadAuctionPostRepositoryImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/impl/CustomReadAuctionPostRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.skyhorsemanpower.BE_AuctionPost.repository.mongotemplate.impl;
 
 import com.skyhorsemanpower.BE_AuctionPost.common.CustomException;
+import com.skyhorsemanpower.BE_AuctionPost.data.dto.InfluencerAllAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.SearchAllAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.domain.cqrs.read.ReadAuctionPost;
 import com.skyhorsemanpower.BE_AuctionPost.repository.mongotemplate.CustomReadAuctionPostRepository;
@@ -8,6 +9,7 @@ import com.skyhorsemanpower.BE_AuctionPost.status.ResponseStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -48,7 +50,7 @@ public class CustomReadAuctionPostRepositoryImpl implements CustomReadAuctionPos
             hasCriteria = true;
         }
 
-        log.info("hasCriteria >>> {}", hasCriteria);
+        log.info("findAllAuctionPost's hasCriteria >>> {}", hasCriteria);
 
         // criteria가 비어있는 경우
         if(!hasCriteria) {
@@ -70,4 +72,43 @@ public class CustomReadAuctionPostRepositoryImpl implements CustomReadAuctionPos
                 () -> mongoTemplate.count(query.skip(-1).limit(-1), ReadAuctionPost.class)
         );
     }
+
+    @Override
+    public Page<ReadAuctionPost> findAllInfluencerAuctionPost(InfluencerAllAuctionPostDto influencerAllAuctionPostDto, Pageable pageable) {
+        log.info("SearchAllAuctionDto >>> {}", influencerAllAuctionPostDto.toString());
+
+        Criteria criteria = new Criteria();
+        boolean hasCriteria = false;
+
+        if (influencerAllAuctionPostDto.getInfluencerUuid() != null) {
+            criteria.and("influencerUuid").is(influencerAllAuctionPostDto.getInfluencerUuid());
+            hasCriteria = true;
+        }
+
+        if (influencerAllAuctionPostDto.getAuctionState() != null) {
+            criteria.and("state").is(influencerAllAuctionPostDto.getAuctionState());
+            hasCriteria = true;
+        }
+
+        log.info("findAllInfluencerAuctionPost's hasCriteria >>> {}", hasCriteria);
+
+        // criteria가 비어있는 경우
+        if(!hasCriteria) {
+            log.info("criteria is blank");
+            throw new CustomException(ResponseStatus.NO_DATA);
+        }
+
+        Query query = new Query(criteria).with(pageable)
+                .skip(pageable.getPageSize() * pageable.getPageNumber())
+                .limit(pageable.getPageSize());
+
+        log.info("Qeury >>> {}", query);
+
+        List<ReadAuctionPost> auctionPosts = mongoTemplate.find(query, ReadAuctionPost.class);
+
+        return PageableExecutionUtils.getPage(
+                auctionPosts,
+                pageable,
+                () -> mongoTemplate.count(query.skip(-1).limit(-1), ReadAuctionPost.class)
+        );    }
 }


### PR DESCRIPTION
#26 

특정 인플루언서(influencerUuid)를 통해 경매글 리스트 조회 구현했습니다.

또한, 경매 상태에 따라 필터링 되도록 구현했습니다.

전체 경매글 리스트 조회와 로직이 비슷하여 간단하게 보시면 될 듯 합니다.
로컬 Swagger에서 테스트 확인하였습니다.