### PR TITLE
refactor: 경매글 조회 API 분리 및 로직 수정(#44)

### DIFF
--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
@@ -13,10 +13,7 @@ import com.skyhorsemanpower.BE_AuctionPost.domain.cqrs.read.ReadAuctionPost;
 import com.skyhorsemanpower.BE_AuctionPost.repository.AuctionImagesRepository;
 import com.skyhorsemanpower.BE_AuctionPost.repository.cqrs.command.CommandAuctionPostRepository;
 import com.skyhorsemanpower.BE_AuctionPost.repository.cqrs.read.ReadAuctionPostRepository;
-import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
-import com.skyhorsemanpower.BE_AuctionPost.status.PageState;
-import com.skyhorsemanpower.BE_AuctionPost.status.ResponseStatus;
-import com.skyhorsemanpower.BE_AuctionPost.status.TimeZoneChangeEnum;
+import com.skyhorsemanpower.BE_AuctionPost.status.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.SchedulerException;
@@ -64,7 +61,7 @@ public class AuctionPostServiceImpl implements AuctionPostService {
     public SearchAllAuctionPostResponseVo searchAllAuction(SearchAllAuctionPostDto searchAllAuctionDto) {
         // 입력 auctionState가 없는 경우는 모든 경매를 조회한다.
         if (searchAllAuctionDto.getAuctionState() == null)
-            searchAllAuctionDto.setAuctionState(AuctionStateEnum.ALL_AUCTION);
+            searchAllAuctionDto.setAuctionState(AuctionPostFilteringEnum.ALL_AUCTION);
 
         Integer page = searchAllAuctionDto.getPage();
         Integer size = searchAllAuctionDto.getSize();

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
@@ -62,9 +62,9 @@ public class AuctionPostServiceImpl implements AuctionPostService {
     @Override
     @Transactional
     public SearchAllAuctionPostResponseVo searchAllAuction(SearchAllAuctionPostDto searchAllAuctionDto) {
-        // 입력 auctionState가 없는 경우는 진행 중인 것으로 판단한다.
+        // 입력 auctionState가 없는 경우는 모든 경매를 조회한다.
         if (searchAllAuctionDto.getAuctionState() == null)
-            searchAllAuctionDto.setAuctionState(AuctionStateEnum.AUCTION_IS_IN_PROGRESS);
+            searchAllAuctionDto.setAuctionState(AuctionStateEnum.ALL_AUCTION);
 
         Integer page = searchAllAuctionDto.getPage();
         Integer size = searchAllAuctionDto.getSize();

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/dto/SearchAllAuctionPostDto.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/dto/SearchAllAuctionPostDto.java
@@ -1,5 +1,6 @@
 package com.skyhorsemanpower.BE_AuctionPost.data.dto;
 
+import com.skyhorsemanpower.BE_AuctionPost.status.AuctionPostFilteringEnum;
 import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,7 @@ public class SearchAllAuctionPostDto {
     private String uuid;
     private String title;
     private String influencerName;
-    private AuctionStateEnum auctionState;
+    private AuctionPostFilteringEnum auctionState;
     private String localName;
     private Integer page;
     private Integer size;

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/presentation/AuctionPostController.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/presentation/AuctionPostController.java
@@ -8,6 +8,7 @@ import com.skyhorsemanpower.BE_AuctionPost.data.dto.SearchAllAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.SearchAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.*;
 import com.skyhorsemanpower.BE_AuctionPost.repository.cqrs.read.ReadAuctionPostRepository;
+import com.skyhorsemanpower.BE_AuctionPost.status.AuctionPostFilteringEnum;
 import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
 import com.skyhorsemanpower.BE_AuctionPost.status.LocalNameEnum;
 import io.swagger.v3.oas.annotations.Operation;
@@ -42,7 +43,7 @@ public class AuctionPostController {
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size) {
         return new SuccessResponse<>(auctionPostService.searchAllAuction(SearchAllAuctionPostDto.builder()
-                .uuid(uuid).influencerName(influencerName).auctionState(AuctionStateEnum.ALL_AUCTION)
+                .uuid(uuid).influencerName(influencerName).auctionState(AuctionPostFilteringEnum.ALL_AUCTION)
                 .page(page).size(size).build()));
     }
 
@@ -55,7 +56,7 @@ public class AuctionPostController {
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size) {
         return new SuccessResponse<>(auctionPostService.searchAllAuction(SearchAllAuctionPostDto.builder()
-                .uuid(uuid).localName(localName).auctionState(AuctionStateEnum.ALL_AUCTION)
+                .uuid(uuid).localName(localName).auctionState(AuctionPostFilteringEnum.ALL_AUCTION)
                 .page(page).size(size).build()));
     }
 
@@ -68,16 +69,16 @@ public class AuctionPostController {
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size) {
         return new SuccessResponse<>(auctionPostService.searchAllAuction(SearchAllAuctionPostDto.builder()
-                .uuid(uuid).title(title).auctionState(AuctionStateEnum.ALL_AUCTION)
+                .uuid(uuid).title(title).auctionState(AuctionPostFilteringEnum.ALL_AUCTION)
                 .page(page).size(size).build()));
     }
 
-    // 경매 상태에 따른 검색(경매글 상태와 무관)
-    @GetMapping("/search/state/{state}")
+    // 경매 상태에 따른 검색
+    @GetMapping({"/search/state", "/search/state/{state}"})
     @Operation(summary = "상태를 통한 경매글 리스트 조회", description = "상태를 통한 경매글 리스트 조회")
     public SuccessResponse<SearchAllAuctionPostResponseVo> searchAllAuctionPostByState (
             @RequestHeader(required = false) String uuid,
-            @PathVariable("state") AuctionStateEnum state,
+            @PathVariable(value = "state", required = false) AuctionPostFilteringEnum state,
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size) {
         return new SuccessResponse<>(auctionPostService.searchAllAuction(SearchAllAuctionPostDto.builder()

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/presentation/AuctionPostController.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/presentation/AuctionPostController.java
@@ -35,11 +35,11 @@ public class AuctionPostController {
     }
 
     // 인플루언서 이름 검색(경매글 상태와 무관)
-    @GetMapping("/search/influencer/{influencerName}")
+    @GetMapping("/search/influencer")
     @Operation(summary = "인플루언서 이름을 통한 경매글 리스트 조회", description = "인플루언서 이름을 통한 경매글 리스트 조회")
     public SuccessResponse<SearchAllAuctionPostResponseVo> searchAllAuctionPostByInfluencerName (
             @RequestHeader(required = false) String uuid,
-            @PathVariable("influencerName") String influencerName,
+            @RequestParam String influencerName,
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size) {
         return new SuccessResponse<>(auctionPostService.searchAllAuction(SearchAllAuctionPostDto.builder()
@@ -48,11 +48,11 @@ public class AuctionPostController {
     }
 
     // 지역 검색(경매글 상태와 무관)
-    @GetMapping("/search/local/{localName}")
+    @GetMapping("/search/local")
     @Operation(summary = "지역을 통한 경매글 리스트 조회", description = "지역을 통한 경매글 리스트 조회")
     public SuccessResponse<SearchAllAuctionPostResponseVo> searchAllAuctionPostByLocalName (
             @RequestHeader(required = false) String uuid,
-            @PathVariable("localName") String localName,
+            @RequestParam String localName,
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size) {
         return new SuccessResponse<>(auctionPostService.searchAllAuction(SearchAllAuctionPostDto.builder()
@@ -61,11 +61,11 @@ public class AuctionPostController {
     }
 
     // 제목 검색(경매글 상태와 무관)
-    @GetMapping("/search/title/{title}")
+    @GetMapping("/search/title")
     @Operation(summary = "제목을 통한 경매글 리스트 조회", description = "제목을 통한 경매글 리스트 조회")
     public SuccessResponse<SearchAllAuctionPostResponseVo> searchAllAuctionPostByTitle (
             @RequestHeader(required = false) String uuid,
-            @PathVariable("title") String title,
+            @RequestParam String title,
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size) {
         return new SuccessResponse<>(auctionPostService.searchAllAuction(SearchAllAuctionPostDto.builder()
@@ -74,11 +74,11 @@ public class AuctionPostController {
     }
 
     // 경매 상태에 따른 검색
-    @GetMapping({"/search/state", "/search/state/{state}"})
+    @GetMapping("/search/state")
     @Operation(summary = "상태를 통한 경매글 리스트 조회", description = "상태를 통한 경매글 리스트 조회")
     public SuccessResponse<SearchAllAuctionPostResponseVo> searchAllAuctionPostByState (
             @RequestHeader(required = false) String uuid,
-            @PathVariable(value = "state", required = false) AuctionPostFilteringEnum state,
+            @RequestParam(required = false) AuctionPostFilteringEnum state,
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size) {
         return new SuccessResponse<>(auctionPostService.searchAllAuction(SearchAllAuctionPostDto.builder()

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/presentation/AuctionPostController.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/presentation/AuctionPostController.java
@@ -9,6 +9,7 @@ import com.skyhorsemanpower.BE_AuctionPost.data.dto.SearchAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.*;
 import com.skyhorsemanpower.BE_AuctionPost.repository.cqrs.read.ReadAuctionPostRepository;
 import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
+import com.skyhorsemanpower.BE_AuctionPost.status.LocalNameEnum;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -32,20 +33,56 @@ public class AuctionPostController {
         return new SuccessResponse<>(null);
     }
 
-    // 경매글 리스트 조회
-    @GetMapping("/search")
-    @Operation(summary = "경매 리스트 조회", description = "경매 리스트 조회")
-    public SuccessResponse<SearchAllAuctionPostResponseVo> searchAllAuctionPost (
+    // 인플루언서 이름 검색(경매글 상태와 무관)
+    @GetMapping("/search/influencer/{influencerName}")
+    @Operation(summary = "인플루언서 이름을 통한 경매글 리스트 조회", description = "인플루언서 이름을 통한 경매글 리스트 조회")
+    public SuccessResponse<SearchAllAuctionPostResponseVo> searchAllAuctionPostByInfluencerName (
             @RequestHeader(required = false) String uuid,
-            @RequestParam(required = false) String title,
-            @RequestParam(required = false) String influencerName,
-            @RequestParam(required = false) AuctionStateEnum auctionState,
-            @RequestParam(required = false) String localName,
+            @PathVariable("influencerName") String influencerName,
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size) {
         return new SuccessResponse<>(auctionPostService.searchAllAuction(SearchAllAuctionPostDto.builder()
-                        .uuid(uuid).title(title).influencerName(influencerName).auctionState(auctionState)
-                        .localName(localName).page(page).size(size).build()));
+                .uuid(uuid).influencerName(influencerName).auctionState(AuctionStateEnum.ALL_AUCTION)
+                .page(page).size(size).build()));
+    }
+
+    // 지역 검색(경매글 상태와 무관)
+    @GetMapping("/search/local/{localName}")
+    @Operation(summary = "지역을 통한 경매글 리스트 조회", description = "지역을 통한 경매글 리스트 조회")
+    public SuccessResponse<SearchAllAuctionPostResponseVo> searchAllAuctionPostByLocalName (
+            @RequestHeader(required = false) String uuid,
+            @PathVariable("localName") String localName,
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size) {
+        return new SuccessResponse<>(auctionPostService.searchAllAuction(SearchAllAuctionPostDto.builder()
+                .uuid(uuid).localName(localName).auctionState(AuctionStateEnum.ALL_AUCTION)
+                .page(page).size(size).build()));
+    }
+
+    // 제목 검색(경매글 상태와 무관)
+    @GetMapping("/search/title/{title}")
+    @Operation(summary = "제목을 통한 경매글 리스트 조회", description = "제목을 통한 경매글 리스트 조회")
+    public SuccessResponse<SearchAllAuctionPostResponseVo> searchAllAuctionPostByTitle (
+            @RequestHeader(required = false) String uuid,
+            @PathVariable("title") String title,
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size) {
+        return new SuccessResponse<>(auctionPostService.searchAllAuction(SearchAllAuctionPostDto.builder()
+                .uuid(uuid).title(title).auctionState(AuctionStateEnum.ALL_AUCTION)
+                .page(page).size(size).build()));
+    }
+
+    // 경매 상태에 따른 검색(경매글 상태와 무관)
+    @GetMapping("/search/state/{state}")
+    @Operation(summary = "상태를 통한 경매글 리스트 조회", description = "상태를 통한 경매글 리스트 조회")
+    public SuccessResponse<SearchAllAuctionPostResponseVo> searchAllAuctionPostByState (
+            @RequestHeader(required = false) String uuid,
+            @PathVariable("state") AuctionStateEnum state,
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer size) {
+        return new SuccessResponse<>(auctionPostService.searchAllAuction(SearchAllAuctionPostDto.builder()
+                .uuid(uuid).auctionState(state)
+                .page(page).size(size).build()));
     }
 
     // 경매글 상세조회

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/impl/CustomReadAuctionPostRepositoryImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/impl/CustomReadAuctionPostRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.skyhorsemanpower.BE_AuctionPost.data.dto.InfluencerAllAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.SearchAllAuctionPostDto;
 import com.skyhorsemanpower.BE_AuctionPost.domain.cqrs.read.ReadAuctionPost;
 import com.skyhorsemanpower.BE_AuctionPost.repository.mongotemplate.CustomReadAuctionPostRepository;
+import com.skyhorsemanpower.BE_AuctionPost.status.AuctionPostFilteringEnum;
 import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
 import com.skyhorsemanpower.BE_AuctionPost.status.ResponseStatus;
 import lombok.RequiredArgsConstructor;
@@ -38,7 +39,7 @@ public class CustomReadAuctionPostRepositoryImpl implements CustomReadAuctionPos
         if (searchAllAuctionDto.getAuctionState() != null) {
 
             // 모든 경매글 검색
-            if (searchAllAuctionDto.getAuctionState().equals(AuctionStateEnum.ALL_AUCTION)) {
+            if (searchAllAuctionDto.getAuctionState().equals(AuctionPostFilteringEnum.ALL_AUCTION)) {
                 // ne는 not equal 이라는 의미
                 criteria.and("state").ne(null);
                 hasCriteria = true;

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/impl/CustomReadAuctionPostRepositoryImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/impl/CustomReadAuctionPostRepositoryImpl.java
@@ -36,8 +36,19 @@ public class CustomReadAuctionPostRepositoryImpl implements CustomReadAuctionPos
         boolean hasCriteria = false;
 
         if (searchAllAuctionDto.getAuctionState() != null) {
-            criteria.and("state").is(searchAllAuctionDto.getAuctionState());
-            hasCriteria = true;
+
+            // 모든 경매글 검색
+            if (searchAllAuctionDto.getAuctionState().equals(AuctionStateEnum.ALL_AUCTION)) {
+                // ne는 not equal 이라는 의미
+                criteria.and("state").ne(null);
+                hasCriteria = true;
+            }
+
+            // 특정 상태 경매글 검색
+            else {
+                criteria.and("state").is(searchAllAuctionDto.getAuctionState());
+                hasCriteria = true;
+            }
         }
         if (searchAllAuctionDto.getTitle() != null) {
             criteria.and("title").regex(searchAllAuctionDto.getTitle(), "i");

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/status/AuctionPostFilteringEnum.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/status/AuctionPostFilteringEnum.java
@@ -5,7 +5,9 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum AuctionStateEnum {
+public enum AuctionPostFilteringEnum {
+    // 모든 경매글 검색을 위해 선언한 필드
+    ALL_AUCTION,
     // 경매 진행 전
     BEFORE_AUCTION,
     // 경매 진행 중

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/status/AuctionStateEnum.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/status/AuctionStateEnum.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AuctionStateEnum {
+    // 모든 경매글 검색을 위해 선언한 필드
+    ALL_AUCTION,
     // 경매 진행 전
     BEFORE_AUCTION,
     // 경매 진행 중


### PR DESCRIPTION
#44 
기존 경매글 조회 API를 삭제 및 분리하였습니다.
필터링 결과에 상태 관련없이 전체 경매글 조회로 되어있습니다.