### PR TITLE
Feature/#74

### DIFF
--- a/src/main/generated/com/skyhorsemanpower/BE_AuctionPost/common/QBaseCreateAndEndTimeEntity.java
+++ b/src/main/generated/com/skyhorsemanpower/BE_AuctionPost/common/QBaseCreateAndEndTimeEntity.java
@@ -19,9 +19,9 @@ public class QBaseCreateAndEndTimeEntity extends EntityPathBase<BaseCreateAndEnd
 
     public static final QBaseCreateAndEndTimeEntity baseCreateAndEndTimeEntity = new QBaseCreateAndEndTimeEntity("baseCreateAndEndTimeEntity");
 
-    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+    public final NumberPath<Long> createdAt = createNumber("createdAt", Long.class);
 
-    public final DateTimePath<java.time.LocalDateTime> updatedAt = createDateTime("updatedAt", java.time.LocalDateTime.class);
+    public final NumberPath<Long> updatedAt = createNumber("updatedAt", Long.class);
 
     public QBaseCreateAndEndTimeEntity(String variable) {
         super(BaseCreateAndEndTimeEntity.class, forVariable(variable));

--- a/src/main/generated/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/command/QCommandAuctionPost.java
+++ b/src/main/generated/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/command/QCommandAuctionPost.java
@@ -23,24 +23,24 @@ public class QCommandAuctionPost extends EntityPathBase<CommandAuctionPost> {
 
     public final StringPath adminUuid = createString("adminUuid");
 
-    public final DateTimePath<java.time.LocalDateTime> auctionEndTime = createDateTime("auctionEndTime", java.time.LocalDateTime.class);
+    public final NumberPath<Long> auctionEndTime = createNumber("auctionEndTime", Long.class);
 
     public final NumberPath<Long> auctionPostId = createNumber("auctionPostId", Long.class);
 
-    public final DateTimePath<java.time.LocalDateTime> auctionStartTime = createDateTime("auctionStartTime", java.time.LocalDateTime.class);
+    public final NumberPath<Long> auctionStartTime = createNumber("auctionStartTime", Long.class);
 
     public final StringPath auctionUuid = createString("auctionUuid");
 
     public final StringPath content = createString("content");
 
     //inherited
-    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+    public final NumberPath<Long> createdAt = _super.createdAt;
 
-    public final DateTimePath<java.time.LocalDateTime> eventCloseTime = createDateTime("eventCloseTime", java.time.LocalDateTime.class);
+    public final NumberPath<Long> eventCloseTime = createNumber("eventCloseTime", Long.class);
 
     public final StringPath eventPlace = createString("eventPlace");
 
-    public final DateTimePath<java.time.LocalDateTime> eventStartTime = createDateTime("eventStartTime", java.time.LocalDateTime.class);
+    public final NumberPath<Long> eventStartTime = createNumber("eventStartTime", Long.class);
 
     public final NumberPath<java.math.BigDecimal> incrementUnit = createNumber("incrementUnit", java.math.BigDecimal.class);
 
@@ -61,7 +61,7 @@ public class QCommandAuctionPost extends EntityPathBase<CommandAuctionPost> {
     public final NumberPath<java.math.BigDecimal> totalDonation = createNumber("totalDonation", java.math.BigDecimal.class);
 
     //inherited
-    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
+    public final NumberPath<Long> updatedAt = _super.updatedAt;
 
     public QCommandAuctionPost(String variable) {
         super(CommandAuctionPost.class, forVariable(variable));

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
@@ -25,6 +25,7 @@ import com.skyhorsemanpower.BE_AuctionPost.status.AuctionPostFilteringEnum;
 import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
 import com.skyhorsemanpower.BE_AuctionPost.status.PageState;
 import com.skyhorsemanpower.BE_AuctionPost.status.ResponseStatus;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -126,11 +127,11 @@ public class AuctionPostServiceImpl implements AuctionPostService {
                 .eventCloseTime(readAuctionPost.getEventCloseTime())
                 .auctionStartTime(readAuctionPost.getAuctionStartTime())
                 .auctionEndTime(readAuctionPost.getAuctionEndTime())
-                .startPrice(readAuctionPost.getStartPrice())
-                .totalDonation(readAuctionPost.getTotalDonation())
+                .startPrice(new BigDecimal(readAuctionPost.getStartPrice()))
+                .totalDonation(new BigDecimal(readAuctionPost.getTotalDonation()))
                 .state(readAuctionPost.getState())
                 .thumbnail(thumbnail)
-                .incrementUnit(readAuctionPost.getIncrementUnit())
+                .incrementUnit(new BigDecimal(readAuctionPost.getIncrementUnit()))
                 .build());
         }
 
@@ -149,6 +150,13 @@ public class AuctionPostServiceImpl implements AuctionPostService {
             searchAuctionPostDto.getAuctionUuid()).orElseThrow(
             () -> new CustomException(ResponseStatus.NO_DATA)
         );
+
+        BigDecimal totalDonation = BigDecimal.ZERO;
+
+        if (readAuctionPost.getTotalDonation() != null) {
+            totalDonation = new BigDecimal(readAuctionPost.getTotalDonation());
+        }
+
         return SearchAuctionResponseVo.builder()
             .readAuctionPost(AllAuctionPostDto.builder()
                 .auctionPostId(readAuctionPost.getAuctionPostId())
@@ -164,9 +172,9 @@ public class AuctionPostServiceImpl implements AuctionPostService {
                 .eventCloseTime(readAuctionPost.getEventCloseTime())
                 .auctionStartTime(readAuctionPost.getAuctionStartTime())
                 .auctionEndTime(readAuctionPost.getAuctionEndTime())
-                .startPrice(readAuctionPost.getStartPrice())
-                .incrementUnit(readAuctionPost.getIncrementUnit())
-                .totalDonation(readAuctionPost.getTotalDonation())
+                .startPrice(new BigDecimal(readAuctionPost.getStartPrice()))
+                .incrementUnit(new BigDecimal(readAuctionPost.getIncrementUnit()))
+                .totalDonation(totalDonation)
                 .state(readAuctionPost.getState())
                 .createdAt(readAuctionPost.getCreatedAt())
                 .updatedAt(readAuctionPost.getUpdatedAt())
@@ -228,11 +236,11 @@ public class AuctionPostServiceImpl implements AuctionPostService {
                 .eventCloseTime(readAuctionPost.getEventCloseTime())
                 .auctionStartTime(readAuctionPost.getAuctionStartTime())
                 .auctionEndTime(readAuctionPost.getAuctionEndTime())
-                .startPrice(readAuctionPost.getStartPrice())
-                .totalDonation(readAuctionPost.getTotalDonation())
+                .startPrice(new BigDecimal(readAuctionPost.getStartPrice()))
+                .totalDonation(new BigDecimal(readAuctionPost.getTotalDonation()))
                 .state(readAuctionPost.getState())
                 .thumbnail(thumbnail)
-                .incrementUnit(readAuctionPost.getIncrementUnit())
+                .incrementUnit(new BigDecimal(readAuctionPost.getIncrementUnit()))
                 .build());
         }
 

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/common/BaseCreateAndEndTimeEntity.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/common/BaseCreateAndEndTimeEntity.java
@@ -3,6 +3,9 @@ package com.skyhorsemanpower.BE_AuctionPost.common;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.Instant;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
@@ -20,9 +23,21 @@ public class BaseCreateAndEndTimeEntity {
 
     @CreatedDate
     @Column(updatable = false, nullable = false)
-    private LocalDateTime createdAt;
+    private long createdAt;
 
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private long updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        long now = Instant.now().toEpochMilli();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = Instant.now().toEpochMilli();
+    }
 }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/common/DateTimeConverter.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/common/DateTimeConverter.java
@@ -1,0 +1,17 @@
+package com.skyhorsemanpower.BE_AuctionPost.common;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public class DateTimeConverter {
+
+    public static LocalDateTime instantToLocalDateTime(long longOfInstant) {
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(longOfInstant), ZoneId.systemDefault());
+    }
+
+    public static long localDateTimeToInstant(LocalDateTime localDateTime) {
+        return localDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+    }
+
+}

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/dto/AllAuctionPostDto.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/dto/AllAuctionPostDto.java
@@ -1,0 +1,33 @@
+package com.skyhorsemanpower.BE_AuctionPost.data.dto;
+
+import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AllAuctionPostDto {
+
+    private String auctionPostId;
+    private String auctionUuid;
+    private String adminUuid;
+    private String influencerUuid;
+    private String influencerName;
+    private String title;
+    private String content;
+    private int numberOfEventParticipants;
+    private String localName;
+    private String eventPlace;
+    private long eventStartTime;
+    private long eventCloseTime;
+    private long auctionStartTime;
+    private long auctionEndTime;
+    private BigDecimal startPrice;
+    private BigDecimal incrementUnit;
+    private BigDecimal totalDonation;
+    private AuctionStateEnum state;
+    private long createdAt;
+    private long updatedAt;
+
+}

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/dto/AuctionPostDto.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/dto/AuctionPostDto.java
@@ -1,16 +1,17 @@
 package com.skyhorsemanpower.BE_AuctionPost.data.dto;
 
+import com.skyhorsemanpower.BE_AuctionPost.common.DateTimeConverter;
 import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-
 @Getter
 @NoArgsConstructor
 public class AuctionPostDto {
+
     private String auctionUuid;
     private String influencerUuid;
     private String influencerName;
@@ -29,20 +30,22 @@ public class AuctionPostDto {
     private BigDecimal incrementUnit;
 
     @Builder
-    public AuctionPostDto(String auctionUuid, String influencerUuid, String influencerName, String title,
-                          String localName, String eventPlace, LocalDateTime eventStartTime, AuctionStateEnum state,
-                          LocalDateTime eventCloseTime, LocalDateTime auctionStartTime, LocalDateTime auctionEndTime,
-                          BigDecimal startPrice, BigDecimal totalDonation, String thumbnail, BigDecimal incrementUnit) {
+    public AuctionPostDto(String auctionUuid, String influencerUuid, String influencerName,
+        String title,
+        String localName, String eventPlace, long eventStartTime, AuctionStateEnum state,
+        long eventCloseTime, long auctionStartTime, long auctionEndTime,
+        BigDecimal startPrice, BigDecimal totalDonation, String thumbnail,
+        BigDecimal incrementUnit) {
         this.auctionUuid = auctionUuid;
         this.influencerUuid = influencerUuid;
         this.influencerName = influencerName;
         this.title = title;
         this.localName = localName;
         this.eventPlace = eventPlace;
-        this.eventStartTime = eventStartTime;
-        this.eventCloseTime = eventCloseTime;
-        this.auctionStartTime = auctionStartTime;
-        this.auctionEndTime = auctionEndTime;
+        this.eventStartTime = DateTimeConverter.instantToLocalDateTime(eventStartTime);
+        this.eventCloseTime = DateTimeConverter.instantToLocalDateTime(eventCloseTime);
+        this.auctionStartTime = DateTimeConverter.instantToLocalDateTime(auctionStartTime);
+        this.auctionEndTime = DateTimeConverter.instantToLocalDateTime(auctionEndTime);
         this.startPrice = startPrice;
         this.totalDonation = totalDonation;
         this.state = state;

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/dto/CreateAuctionPostDto.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/dto/CreateAuctionPostDto.java
@@ -1,19 +1,19 @@
 package com.skyhorsemanpower.BE_AuctionPost.data.dto;
 
+import com.skyhorsemanpower.BE_AuctionPost.common.DateTimeConverter;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.CreateAuctionPostRequestVo;
+import java.math.BigDecimal;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.List;
-
 @Getter
 @Setter
 @NoArgsConstructor
 public class CreateAuctionPostDto {
+
     private String adminUuid;
     private String influencerUuid;
     private String influencerName;
@@ -22,9 +22,9 @@ public class CreateAuctionPostDto {
     private int numberOfEventParticipants;
     private String localName;
     private String eventPlace;
-    private LocalDateTime eventStartTime;
-    private LocalDateTime eventCloseTime;
-    private LocalDateTime auctionStartTime;
+    private long eventStartTime;
+    private long eventCloseTime;
+    private long auctionStartTime;
     private BigDecimal startPrice;
     private BigDecimal incrementUnit;
     private String thumbnail;
@@ -32,11 +32,12 @@ public class CreateAuctionPostDto {
     private String auctionUuid;
 
     @Builder
-    public CreateAuctionPostDto(String adminUuid, String influencerUuid, String influencerName, String title,
-                                String content, int numberOfEventParticipants, String localName, String eventPlace,
-                                LocalDateTime eventStartTime, LocalDateTime eventCloseTime,
-                                LocalDateTime auctionStartTime, BigDecimal startPrice,
-                                BigDecimal incrementUnit, String thumbnail, List<String> images, String auctionUuid) {
+    public CreateAuctionPostDto(String adminUuid, String influencerUuid, String influencerName,
+        String title,
+        String content, int numberOfEventParticipants, String localName, String eventPlace,
+        long eventStartTime, long eventCloseTime,
+        long auctionStartTime, BigDecimal startPrice,
+        BigDecimal incrementUnit, String thumbnail, List<String> images, String auctionUuid) {
         this.adminUuid = adminUuid;
         this.influencerUuid = influencerUuid;
         this.influencerName = influencerName;
@@ -56,24 +57,33 @@ public class CreateAuctionPostDto {
     }
 
 
-
-    public static CreateAuctionPostDto voToDto(String uuid, CreateAuctionPostRequestVo createAuctionPostRequestVo) {
+    public static CreateAuctionPostDto voToDto(String uuid,
+        CreateAuctionPostRequestVo createAuctionPostRequestVo) {
         return CreateAuctionPostDto.builder()
-                .adminUuid(uuid)
-                .influencerUuid(createAuctionPostRequestVo.getInfluencerUuid())
-                .influencerName(createAuctionPostRequestVo.getInfluencerName())
-                .title(createAuctionPostRequestVo.getTitle())
-                .content(createAuctionPostRequestVo.getContent())
-                .numberOfEventParticipants(createAuctionPostRequestVo.getNumberOfEventParticipants())
-                .localName(createAuctionPostRequestVo.getLocalName())
-                .eventPlace(createAuctionPostRequestVo.getEventPlace())
-                .eventStartTime(createAuctionPostRequestVo.getEventStartTime())
-                .eventCloseTime(createAuctionPostRequestVo.getEventCloseTime())
-                .auctionStartTime(createAuctionPostRequestVo.getAuctionStartTime())
-                .startPrice(createAuctionPostRequestVo.getStartPrice())
-                .incrementUnit(createAuctionPostRequestVo.getIncrementUnit())
-                .thumbnail(createAuctionPostRequestVo.getThumbnail())
-                .images(createAuctionPostRequestVo.getImages())
-                .build();
+            .adminUuid(uuid)
+            .influencerUuid(createAuctionPostRequestVo.getInfluencerUuid())
+            .influencerName(createAuctionPostRequestVo.getInfluencerName())
+            .title(createAuctionPostRequestVo.getTitle())
+            .content(createAuctionPostRequestVo.getContent())
+            .numberOfEventParticipants(createAuctionPostRequestVo.getNumberOfEventParticipants())
+            .localName(createAuctionPostRequestVo.getLocalName())
+            .eventPlace(createAuctionPostRequestVo.getEventPlace())
+            .eventStartTime(
+                DateTimeConverter.localDateTimeToInstant(
+                    createAuctionPostRequestVo.getEventStartTime())
+            )
+            .eventCloseTime(
+                DateTimeConverter.localDateTimeToInstant(
+                    createAuctionPostRequestVo.getEventCloseTime())
+            )
+            .auctionStartTime(
+                DateTimeConverter.localDateTimeToInstant(
+                    createAuctionPostRequestVo.getAuctionStartTime())
+            )
+            .startPrice(createAuctionPostRequestVo.getStartPrice())
+            .incrementUnit(createAuctionPostRequestVo.getIncrementUnit())
+            .thumbnail(createAuctionPostRequestVo.getThumbnail())
+            .images(createAuctionPostRequestVo.getImages())
+            .build();
     }
 }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/vo/SearchAuctionResponseVo.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/vo/SearchAuctionResponseVo.java
@@ -1,25 +1,66 @@
 package com.skyhorsemanpower.BE_AuctionPost.data.vo;
 
-import com.skyhorsemanpower.BE_AuctionPost.domain.cqrs.read.ReadAuctionPost;
+import com.skyhorsemanpower.BE_AuctionPost.common.DateTimeConverter;
+import com.skyhorsemanpower.BE_AuctionPost.data.dto.AllAuctionPostDto;
+import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-import java.util.List;
-
 @Getter
 @ToString
 @NoArgsConstructor
 public class SearchAuctionResponseVo {
-    private ReadAuctionPost readAuctionPost;
+
+    private String auctionPostId;
+    private String auctionUuid;
+    private String adminUuid;
+    private String influencerUuid;
+    private String influencerName;
+    private String title;
+    private String content;
+    private int numberOfEventParticipants;
+    private String localName;
+    private String eventPlace;
+    private LocalDateTime eventStartTime;
+    private LocalDateTime eventCloseTime;
+    private LocalDateTime auctionStartTime;
+    private LocalDateTime auctionEndTime;
+    private BigDecimal startPrice;
+    private BigDecimal incrementUnit;
+    private BigDecimal totalDonation;
+    private AuctionStateEnum state;
+    private long createdAt;
+    private long updatedAt;
 
     private String thumbnail;
     private List<String> images;
 
     @Builder
-    public SearchAuctionResponseVo(ReadAuctionPost readAuctionPost, String thumbnail, List<String> images) {
-        this.readAuctionPost = readAuctionPost;
+    public SearchAuctionResponseVo(AllAuctionPostDto readAuctionPost, String thumbnail,
+        List<String> images) {
+        this.auctionPostId = readAuctionPost.getAuctionPostId();
+        this.auctionUuid = readAuctionPost.getAuctionUuid();
+        this.adminUuid = readAuctionPost.getAdminUuid();
+        this.influencerUuid = readAuctionPost.getInfluencerUuid();
+        this.influencerName = readAuctionPost.getInfluencerName();
+        this.title = readAuctionPost.getTitle();
+        this.content = readAuctionPost.getContent();
+        this.numberOfEventParticipants = readAuctionPost.getNumberOfEventParticipants();
+        this.localName = readAuctionPost.getLocalName();
+        this.eventPlace = readAuctionPost.getEventPlace();
+        this.eventStartTime = DateTimeConverter.instantToLocalDateTime(
+            readAuctionPost.getEventStartTime());
+        this.eventCloseTime = DateTimeConverter.instantToLocalDateTime(
+            readAuctionPost.getEventCloseTime());
+        this.auctionStartTime = DateTimeConverter.instantToLocalDateTime(
+            readAuctionPost.getAuctionStartTime());
+        this.auctionEndTime = DateTimeConverter.instantToLocalDateTime(
+            readAuctionPost.getAuctionEndTime());
         this.thumbnail = thumbnail;
         this.images = images;
     }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/vo/SearchAuctionResponseVo.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/vo/SearchAuctionResponseVo.java
@@ -61,6 +61,12 @@ public class SearchAuctionResponseVo {
             readAuctionPost.getAuctionStartTime());
         this.auctionEndTime = DateTimeConverter.instantToLocalDateTime(
             readAuctionPost.getAuctionEndTime());
+        this.startPrice = readAuctionPost.getStartPrice();
+        this.incrementUnit = readAuctionPost.getIncrementUnit();
+        this.totalDonation = readAuctionPost.getTotalDonation();
+        this.state = readAuctionPost.getState();
+        this.createdAt = readAuctionPost.getCreatedAt();
+        this.updatedAt = readAuctionPost.getUpdatedAt();
         this.thumbnail = thumbnail;
         this.images = images;
     }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/command/CommandAuctionPost.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/command/CommandAuctionPost.java
@@ -2,12 +2,20 @@ package com.skyhorsemanpower.BE_AuctionPost.domain.cqrs.command;
 
 import com.skyhorsemanpower.BE_AuctionPost.common.BaseCreateAndEndTimeEntity;
 import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
-import jakarta.persistence.*;
-import lombok.*;
-import org.springframework.cglib.core.Local;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @Getter
@@ -49,16 +57,16 @@ public class CommandAuctionPost extends BaseCreateAndEndTimeEntity {
     private String eventPlace;
 
     @Column(nullable = false, length = 30)
-    private LocalDateTime eventStartTime;
+    private long eventStartTime;
 
     @Column(nullable = false, length = 30)
-    private LocalDateTime eventCloseTime;
+    private long eventCloseTime;
 
     @Column(nullable = false, length = 30)
-    private LocalDateTime auctionStartTime;
+    private long auctionStartTime;
 
     @Column(nullable = false, length = 30)
-    private LocalDateTime auctionEndTime;
+    private long auctionEndTime;
 
     @Column(nullable = false, precision = 20, scale = 2)
     private BigDecimal startPrice;
@@ -75,12 +83,13 @@ public class CommandAuctionPost extends BaseCreateAndEndTimeEntity {
 
 
     @Builder
-    public CommandAuctionPost(long auctionPostId, String auctionUuid, String adminUuid, String influencerUuid,
-                              String influencerName, String title, String content, int numberOfEventParticipants,
-                              String localName, String eventPlace, LocalDateTime eventStartTime,
-                              LocalDateTime auctionEndTime, LocalDateTime eventCloseTime,
-                              LocalDateTime auctionStartTime, BigDecimal startPrice, BigDecimal incrementUnit,
-                              BigDecimal totalDonation, AuctionStateEnum state) {
+    public CommandAuctionPost(long auctionPostId, String auctionUuid, String adminUuid,
+        String influencerUuid,
+        String influencerName, String title, String content, int numberOfEventParticipants,
+        String localName, String eventPlace, long eventStartTime,
+        long auctionEndTime, long eventCloseTime,
+        long auctionStartTime, BigDecimal startPrice, BigDecimal incrementUnit,
+        BigDecimal totalDonation, AuctionStateEnum state) {
         this.auctionPostId = auctionPostId;
         this.auctionUuid = auctionUuid;
         this.adminUuid = adminUuid;

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/read/ReadAuctionPost.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/read/ReadAuctionPost.java
@@ -1,18 +1,15 @@
 package com.skyhorsemanpower.BE_AuctionPost.domain.cqrs.read;
 
 import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
-import jakarta.persistence.Column;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import java.math.BigDecimal;
+import java.time.Instant;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
-
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 @NoArgsConstructor
 @Getter
@@ -21,35 +18,55 @@ import java.time.LocalDateTime;
 public class ReadAuctionPost {
 
     @Id
+    @Field(name = "auction_post_id")
     private String auctionPostId;
-
+    @Field(name = "auction_uuid")
     private String auctionUuid;
+    @Field(name = "admin_uuid")
     private String adminUuid;
+    @Field(name = "influencer_uuid")
     private String influencerUuid;
+    @Field(name = "influencer_name")
     private String influencerName;
+    @Field(name = "title")
     private String title;
+    @Field(name = "content")
     private String content;
+    @Field(name = "number_of_event_participants")
     private int numberOfEventParticipants;
+    @Field(name = "local_name")
     private String localName;
+    @Field(name = "event_place")
     private String eventPlace;
-    private LocalDateTime eventStartTime;
-    private LocalDateTime eventCloseTime;
-    private LocalDateTime auctionStartTime;
-    private LocalDateTime auctionEndTime;
+    @Field(name = "event_start_time")
+    private long eventStartTime;
+    @Field(name = "event_close_time")
+    private long eventCloseTime;
+    @Field(name = "auction_start_time")
+    private long auctionStartTime;
+    @Field(name = "auction_end_time")
+    private long auctionEndTime;
+    @Field(name = "start_price")
     private BigDecimal startPrice;
+    @Field(name = "increment_unit")
     private BigDecimal incrementUnit;
+    @Field(name = "total_donation")
     private BigDecimal totalDonation;
+    @Field(name = "state")
     private AuctionStateEnum state;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    @Field(name = "created_at")
+    private long createdAt;
+    @Field(name = "updated_at")
+    private long updatedAt;
 
     @Builder
-    public ReadAuctionPost(String auctionPostId, String auctionUuid, String adminUuid, String influencerUuid,
-                           String influencerName, String title, String content, int numberOfEventParticipants,
-                           String localName, String eventPlace, LocalDateTime eventStartTime,
-                           LocalDateTime auctionEndTime, LocalDateTime eventCloseTime, LocalDateTime auctionStartTime,
-                           BigDecimal startPrice, BigDecimal incrementUnit, BigDecimal totalDonation,
-                           AuctionStateEnum state) {
+    public ReadAuctionPost(String auctionPostId, String auctionUuid, String adminUuid,
+        String influencerUuid,
+        String influencerName, String title, String content, int numberOfEventParticipants,
+        String localName, String eventPlace, long eventStartTime,
+        long auctionEndTime, long eventCloseTime, long auctionStartTime,
+        BigDecimal startPrice, BigDecimal incrementUnit, BigDecimal totalDonation,
+        AuctionStateEnum state) {
         this.auctionPostId = auctionPostId;
         this.auctionUuid = auctionUuid;
         this.adminUuid = adminUuid;
@@ -68,7 +85,7 @@ public class ReadAuctionPost {
         this.incrementUnit = incrementUnit;
         this.totalDonation = totalDonation;
         this.state = state;
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
+        this.createdAt = Instant.now().toEpochMilli();
+        this.updatedAt = Instant.now().toEpochMilli();
     }
 }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/read/ReadAuctionPost.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/read/ReadAuctionPost.java
@@ -47,11 +47,11 @@ public class ReadAuctionPost {
     @Field(name = "auction_end_time")
     private long auctionEndTime;
     @Field(name = "start_price")
-    private BigDecimal startPrice;
+    private String startPrice;
     @Field(name = "increment_unit")
-    private BigDecimal incrementUnit;
+    private String incrementUnit;
     @Field(name = "total_donation")
-    private BigDecimal totalDonation;
+    private String totalDonation;
     @Field(name = "state")
     private AuctionStateEnum state;
     @Field(name = "created_at")
@@ -65,7 +65,7 @@ public class ReadAuctionPost {
         String influencerName, String title, String content, int numberOfEventParticipants,
         String localName, String eventPlace, long eventStartTime,
         long auctionEndTime, long eventCloseTime, long auctionStartTime,
-        BigDecimal startPrice, BigDecimal incrementUnit, BigDecimal totalDonation,
+        String startPrice, String incrementUnit, String totalDonation,
         AuctionStateEnum state) {
         this.auctionPostId = auctionPostId;
         this.auctionUuid = auctionUuid;


### PR DESCRIPTION
- #74 
- 모든 엔티티의 시간 필드 타입을 `long`으로 수정했습니다. 이유는 `LocalDateTime` 사용 시 CDC를 적용하면 mongodb와 postgresql에 저장되는 값이 달라지기 때문입니다. 그래서 `Instant` 타입을 로직에서 사용하기 위해 `long`타입으로 저장합니다.
- 응답할때는 `LocalDateTime`으로 변환합니다.
- 경매글 생성 시 mongodb에도 저장하는 로직을 제거했습니다.
- `/api/v1/auction-post/{auctionUuid}`의 응답 형태가 flatten json으로 변경되었습니다. 
![image](https://github.com/SKY-HORSE-MAN-POWER/BE_AuctionPost/assets/100576111/41cfa90b-0127-4b82-a7ec-fe49624fa8bf)

- domain패키지, VO, DTO를 중점적으로 봐주시면 감사하겠습니다.