### PR TITLE
Feature/#74

### DIFF
--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
@@ -163,6 +163,7 @@ public class AuctionPostServiceImpl implements AuctionPostService {
                 .auctionUuid(readAuctionPost.getAuctionUuid())
                 .adminUuid(readAuctionPost.getAdminUuid())
                 .influencerUuid(readAuctionPost.getInfluencerUuid())
+                .influencerName(readAuctionPost.getInfluencerName())
                 .title(readAuctionPost.getTitle())
                 .content(readAuctionPost.getContent())
                 .numberOfEventParticipants(readAuctionPost.getNumberOfEventParticipants())

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/vo/SearchAuctionResponseVo.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/data/vo/SearchAuctionResponseVo.java
@@ -34,8 +34,8 @@ public class SearchAuctionResponseVo {
     private BigDecimal incrementUnit;
     private BigDecimal totalDonation;
     private AuctionStateEnum state;
-    private long createdAt;
-    private long updatedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 
     private String thumbnail;
     private List<String> images;
@@ -65,8 +65,8 @@ public class SearchAuctionResponseVo {
         this.incrementUnit = readAuctionPost.getIncrementUnit();
         this.totalDonation = readAuctionPost.getTotalDonation();
         this.state = readAuctionPost.getState();
-        this.createdAt = readAuctionPost.getCreatedAt();
-        this.updatedAt = readAuctionPost.getUpdatedAt();
+        this.createdAt = DateTimeConverter.instantToLocalDateTime(readAuctionPost.getCreatedAt());
+        this.updatedAt = DateTimeConverter.instantToLocalDateTime(readAuctionPost.getUpdatedAt());
         this.thumbnail = thumbnail;
         this.images = images;
     }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/read/ReadAuctionPost.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/domain/cqrs/read/ReadAuctionPost.java
@@ -1,7 +1,6 @@
 package com.skyhorsemanpower.BE_AuctionPost.domain.cqrs.read;
 
 import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
-import java.math.BigDecimal;
 import java.time.Instant;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,7 +17,6 @@ import org.springframework.data.mongodb.core.mapping.Field;
 public class ReadAuctionPost {
 
     @Id
-    @Field(name = "auction_post_id")
     private String auctionPostId;
     @Field(name = "auction_uuid")
     private String auctionUuid;


### PR DESCRIPTION
- 도큐먼트에서 id 필드에 `@Field`를 제거했습니다. CDC로 mongodb에 저장되는 값에는 `aution_post_id`로 저장됩니다.
- 경매글 상세조회 로직에서 인플루언서 이름을 같이 주도록 고쳤습니다.
- 경매글 상세조회 응답 VO에서 `createdAt`, `updatedAt`의 타입을 `LocalDateTime`으로 수정했습니다.
- postgresql에서 캡쳐된 데이터가 mongodb에 다음 사진과 같이 저장됩니다.
![image](https://github.com/SKY-HORSE-MAN-POWER/BE_AuctionPost/assets/100576111/8d056037-b6ee-41d1-acc9-e882d4446cdb)
