### PR TITLE
refactor: 경매글 시작 시간에 사용할 스케줄러 처리 중(#88)

### DIFF
--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/kafka/KafkaProducerCluster.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/kafka/KafkaProducerCluster.java
@@ -1,0 +1,32 @@
+package com.skyhorsemanpower.BE_AuctionPost.kafka;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaProducerCluster {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void sendMessage(String topicName, Object object) {
+        CompletableFuture<SendResult<String, Object>> future =
+            kafkaTemplate.send(topicName, object);
+
+        future.whenComplete((result, ex) -> {
+            if (ex == null) {
+                log.info("producer: success >>> message: {}, offset: {}",
+                    result.getProducerRecord().value().toString(),
+                    result.getRecordMetadata().offset());
+            } else {
+                log.info("producer: failure >>> message: {}", ex.getMessage());
+            }
+        });
+    }
+}

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/kafka/KafkaProducerConfig.java
@@ -1,0 +1,34 @@
+package com.skyhorsemanpower.BE_AuctionPost.kafka;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/kafka/Topics.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/kafka/Topics.java
@@ -1,0 +1,17 @@
+package com.skyhorsemanpower.BE_AuctionPost.kafka;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Topics {
+    INITIAL_AUCTION(Constant.INITIAL_AUCTION)
+    ;
+
+    public static class Constant {
+        public static final String INITIAL_AUCTION = "initial-auction-topic";
+    }
+
+    private final String topic;
+}

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/kafka/dto/InitialAuctionDto.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/kafka/dto/InitialAuctionDto.java
@@ -1,0 +1,51 @@
+package com.skyhorsemanpower.BE_AuctionPost.kafka.dto;
+
+import com.skyhorsemanpower.BE_AuctionPost.data.dto.CreateAuctionPostDto;
+import com.skyhorsemanpower.BE_AuctionPost.status.AuctionEndTimeState;
+import com.skyhorsemanpower.BE_AuctionPost.status.TimeZoneChangeEnum;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class InitialAuctionDto {
+    private String auctionUuid;
+    private BigDecimal startPrice;
+    private int numberOfEventParticipants;
+    private long auctionStartTime;
+    private long auctionEndTime;
+    private BigDecimal incrementUnit;
+
+    @Builder
+    public InitialAuctionDto(String auctionUuid, BigDecimal startPrice, int numberOfEventParticipants,
+                             long auctionStartTime, long auctionEndTime, BigDecimal incrementUnit) {
+        this.auctionUuid = auctionUuid;
+        this.startPrice = startPrice;
+        this.numberOfEventParticipants = numberOfEventParticipants;
+        this.auctionStartTime = auctionStartTime;
+        this.auctionEndTime = auctionEndTime;
+        this.incrementUnit = incrementUnit;
+    }
+
+    //todo
+    // CDC 로직에 맞춰서 바뀔 가능성 존재
+//    public static InitialAuctionDto converter(CreateAuctionPostDto createAuctionPostDto) {
+//        return InitialAuctionDto.builder()
+//                .auctionUuid(createAuctionPostDto.getAuctionUuid())
+//                .startPrice(createAuctionPostDto.getStartPrice())
+//                .numberOfEventParticipants(createAuctionPostDto.getNumberOfEventParticipants())
+//                .auctionStartTime(createAuctionPostDto.getAuctionStartTime()
+//                        .plusHours(TimeZoneChangeEnum.KOREA_TO_UTC.getTimeDiff()))
+//                .auctionEndTime(createAuctionPostDto.getEventCloseTime()
+//                        .plusHours(TimeZoneChangeEnum.KOREA_TO_UTC.getTimeDiff())
+//                        .plusHours(AuctionEndTimeState.TWO_HOUR.getEndTime()))
+//                .incrementUnit(createAuctionPostDto.getIncrementUnit())
+//                .build();
+//    }
+}


### PR DESCRIPTION
경매글 시작 시간에 사용할 스케줄러를 구현하고 있습니다.
기획팀장님이 카프카 설정한 부분에서 이어받아서 진행할려고 합니다.

<해야 할 일>
경매글 생성 서비스 로직에 스케줄러 등록과 카프카 메시지 전송이 분리되어 있습니다.
스케줄러 등록 안에 카프카 메시지 전송 로직을 넣으시면 될 듯 합니다.
