### PR TITLE
Refactor/#88 경매글 생성 시, 경매 서비스에 경매글 관련 데이터 전송

### DIFF
--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
@@ -87,6 +87,12 @@ public class AuctionPostServiceImpl implements AuctionPostService {
                 .startPrice(createAuctionPostDto.getStartPrice())
                 .numberOfEventParticipants(createAuctionPostDto.getNumberOfEventParticipants())
                 .auctionStartTime(createAuctionPostDto.getAuctionStartTime())
+                .auctionEndTime(
+                        Instant.ofEpochMilli(createAuctionPostDto.getAuctionStartTime())
+                                .plus(Duration.ofHours(AuctionEndTimeState.TWO_HOUR.getEndTime()))
+                                .toEpochMilli()
+                )
+                .incrementUnit(createAuctionPostDto.getIncrementUnit())
                 .build();
         log.info("InitialAuctionDto >>> {}", initialAuctionDto.toString());
         producer.sendMessage(Topics.Constant.INITIAL_AUCTION, initialAuctionDto);


### PR DESCRIPTION
경매글 생성하면, 경매 서비스에 카프카로 초기 데이터 전송해서 `round_info`에 저장하고 경매 시작과 경매 마감 스케줄러 처리 구현, 확인했습니다.

경매글 생성되면 경매 서비스에 메시지 수신 확인 및 `round_info` 저장 확인
![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/de883acf-0509-495c-8adb-af051a42e37e)
![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/0ba6145b-c658-40dc-a36a-b35a7f96be96)

경매 시작 시간에 작동한 스케줄러 확인
![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/ee32185d-3d82-476d-89ff-963619c19c14)

경매 마감 시간에 작동한 스케줄러 확인
![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Auction/assets/128444378/0700577b-9a7a-445a-9218-fe1a7d4fa3f2)
