### PR TITLE
feat: 메인페이지에서 경매 진행중, 진행예정인 경매글 10개만 가져 오도록 수정(#95)

### DIFF
--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
@@ -46,6 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.quartz.SchedulerException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -407,37 +408,45 @@ public class AuctionPostServiceImpl implements AuctionPostService {
 	public List<MainPagePostResponseVo> mainPagePost() {
 		List<MainPagePostResponseDto> mainPagePostResponseDtoList = new ArrayList<>();
 
-		List<ReadAuctionPost> result = new ArrayList<>();
-		result.addAll(
-			readAuctionPostRepository.findByState(AuctionStateEnum.AUCTION_IS_IN_PROGRESS.toString()));
-		result.addAll(readAuctionPostRepository.findByState(
-			AuctionStateEnum.BEFORE_AUCTION.toString()));
+		Pageable limit = PageRequest.of(0, 10);
 
-		for (ReadAuctionPost readAuctionPost : result) {
+		Page<ReadAuctionPost> inProgress = readAuctionPostRepository.findByState(
+			AuctionStateEnum.AUCTION_IS_IN_PROGRESS.toString(), limit);
+		List<ReadAuctionPost> result = new ArrayList<>(inProgress.getContent());
 
-			String thumbnail = auctionImagesRepository.getThumbnailUrl(
-				readAuctionPost.getAuctionUuid());
-
-			mainPagePostResponseDtoList.add(MainPagePostResponseDto.builder()
-				.auctionUuid(readAuctionPost.getAuctionUuid())
-				.title(readAuctionPost.getTitle())
-				.eventStartTime(readAuctionPost.getEventStartTime())
-				.state(readAuctionPost.getState())
-				.thumbnail(thumbnail)
-				.build());
+		if (result.size() < 10) {
+			int remain = 10 - result.size();
+			Pageable remainLimit = PageRequest.of(0, remain);
+			result.addAll(readAuctionPostRepository.findByState(
+				AuctionStateEnum.BEFORE_AUCTION.toString(), remainLimit).getContent());
 		}
+
+		result.stream()
+			.map(readAuctionPost -> {
+				String thumbnail = auctionImagesRepository.getThumbnailUrl(
+					readAuctionPost.getAuctionUuid());
+				return MainPagePostResponseDto.builder()
+					.auctionUuid(readAuctionPost.getAuctionUuid())
+					.title(readAuctionPost.getTitle())
+					.eventStartTime(readAuctionPost.getEventStartTime())
+					.state(readAuctionPost.getState())
+					.thumbnail(thumbnail)
+					.build();
+			})
+			.forEach(mainPagePostResponseDtoList::add);
 
 		List<MainPagePostResponseVo> mainPagePostResponseVoList = new ArrayList<>();
 
-		for (MainPagePostResponseDto mainPagePostResponseDto : mainPagePostResponseDtoList) {
-			mainPagePostResponseVoList.add(MainPagePostResponseVo.builder()
-				.auctionUuid(mainPagePostResponseDto.getAuctionUuid())
-				.title(mainPagePostResponseDto.getTitle())
-				.eventStartTime(mainPagePostResponseDto.getEventStartTime())
-				.state(mainPagePostResponseDto.getState())
-				.thumbnail(mainPagePostResponseDto.getThumbnail())
-				.build());
-		}
+		mainPagePostResponseDtoList.stream()
+			.map(mainPagePostResponseDto ->
+				MainPagePostResponseVo.builder()
+					.auctionUuid(mainPagePostResponseDto.getAuctionUuid())
+					.title(mainPagePostResponseDto.getTitle())
+					.eventStartTime(mainPagePostResponseDto.getEventStartTime())
+					.state(mainPagePostResponseDto.getState())
+					.thumbnail(mainPagePostResponseDto.getThumbnail())
+					.build())
+			.forEach(mainPagePostResponseVoList::add);
 
 		return mainPagePostResponseVoList;
 	}

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/cqrs/read/ReadAuctionPostRepository.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/cqrs/read/ReadAuctionPostRepository.java
@@ -14,12 +14,4 @@ public interface ReadAuctionPostRepository extends MongoRepository<ReadAuctionPo
 	CustomReadAuctionPostRepository {
 
 	Optional<ReadAuctionPost> findByAuctionUuid(String auctionUuid);
-
-//	@Query("{ 'state' : 'AUCTION_IS_IN_PROGRESS' }")
-//	List<ReadAuctionPost> findByProgressMainAuctionPosts();
-//
-//	@Query("{ 'state' : 'BEFORE_AUCTION' }")
-//	List<ReadAuctionPost> findByBeforeMainAuctionPosts();
-
-	List<ReadAuctionPost> findByState(String state);
 }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/CustomReadAuctionPostRepository.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/CustomReadAuctionPostRepository.java
@@ -6,6 +6,7 @@ import com.skyhorsemanpower.BE_AuctionPost.data.dto.SearchAuctionPostTitleDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.SearchAuctionPostTitleAndInfluencerNameResponseVo;
 import com.skyhorsemanpower.BE_AuctionPost.domain.cqrs.read.ReadAuctionPost;
 import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -17,4 +18,6 @@ public interface CustomReadAuctionPostRepository {
     void updateStateByAuctionUuid(String auctionUuid, AuctionStateEnum state);
 
     SearchAuctionPostTitleAndInfluencerNameResponseVo getAuctionPostTitleAndInfluencerName(SearchAuctionPostTitleDto searchAuctionPostTitleDto);
+
+    Page<ReadAuctionPost> findByState(String state, Pageable pageable);
 }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/impl/CustomReadAuctionPostRepositoryImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/impl/CustomReadAuctionPostRepositoryImpl.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
@@ -198,8 +199,10 @@ public class CustomReadAuctionPostRepositoryImpl implements CustomReadAuctionPos
         Criteria criteria = new Criteria();
         criteria.and("state").is(state);
 
+        Sort sort = Sort.by(Sort.Order.desc("createdAt"));
+
         Query query = new Query(criteria).with(pageable)
-            .limit(pageable.getPageSize());
+            .limit(pageable.getPageSize()).with(sort);
 
         List<ReadAuctionPost> auctionPosts = mongoTemplate.find(query, ReadAuctionPost.class);
 

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/impl/CustomReadAuctionPostRepositoryImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/impl/CustomReadAuctionPostRepositoryImpl.java
@@ -191,4 +191,22 @@ public class CustomReadAuctionPostRepositoryImpl implements CustomReadAuctionPos
         return SearchAuctionPostTitleAndInfluencerNameResponseVo.builder()
                 .result(result).build();
     }
+
+    @Override
+    public Page<ReadAuctionPost> findByState(String state, Pageable pageable) {
+
+        Criteria criteria = new Criteria();
+        criteria.and("state").is(state);
+
+        Query query = new Query(criteria).with(pageable)
+            .limit(pageable.getPageSize());
+
+        List<ReadAuctionPost> auctionPosts = mongoTemplate.find(query, ReadAuctionPost.class);
+
+        return PageableExecutionUtils.getPage(
+            auctionPosts,
+            pageable,
+            () -> mongoTemplate.count(query.skip(-1).limit(-1), ReadAuctionPost.class)
+        );
+    }
 }


### PR DESCRIPTION
- [x] #95 

메인페이지에서 진행중이거나 진행예정인 경매글 정보를 최신순 10개만 가져오록 만들었습니다.