### PR TITLE
Feature/#115

### DIFF
--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/AuctionPostService.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/AuctionPostService.java
@@ -9,6 +9,8 @@ import com.skyhorsemanpower.BE_AuctionPost.data.vo.MainPagePostResponseVo;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.SearchAllAuctionPostResponseVo;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.SearchAuctionResponseVo;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.AuctionTotalDonationVo;
+import com.skyhorsemanpower.BE_AuctionPost.kafka.dto.EventStartTimeDto;
+import com.skyhorsemanpower.BE_AuctionPost.status.AuctionStateEnum;
 import java.util.List;
 
 public interface AuctionPostService {
@@ -26,4 +28,6 @@ public interface AuctionPostService {
 	void updateTotalDonationAmount(AuctionTotalDonationVo auctionTotalDonationVo);
 
 	List<MainPagePostResponseVo> mainPagePost();
+
+	EventStartTimeDto updateStateByAuctionUuid(String auctionUuid, AuctionStateEnum state);
 }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
@@ -22,6 +22,7 @@ import com.skyhorsemanpower.BE_AuctionPost.domain.AuctionImages;
 import com.skyhorsemanpower.BE_AuctionPost.domain.cqrs.command.CommandAuctionPost;
 import com.skyhorsemanpower.BE_AuctionPost.domain.cqrs.read.ReadAuctionPost;
 import com.skyhorsemanpower.BE_AuctionPost.kafka.KafkaProducerCluster;
+import com.skyhorsemanpower.BE_AuctionPost.kafka.dto.EventStartTimeDto;
 import com.skyhorsemanpower.BE_AuctionPost.kafka.dto.InitialAuctionDto;
 import com.skyhorsemanpower.BE_AuctionPost.repository.AuctionImagesRepository;
 import com.skyhorsemanpower.BE_AuctionPost.repository.cqrs.command.CommandAuctionPostRepository;
@@ -41,6 +42,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
@@ -373,9 +375,9 @@ public class AuctionPostServiceImpl implements AuctionPostService {
 
     @Override
     @Transactional
-    public void updateTotalDonationAmount(UpdateTotalDonationUpdateVo updateTotalDonationUpdateVo) {
+    public void updateTotalDonationAmount(AuctionTotalDonationVo auctionTotalDonationVo) {
         CommandAuctionPost auctionPost = commandAuctionPostRepository.findByAuctionUuid(
-                updateTotalDonationUpdateVo.getAuctionUuid()).orElseThrow(
+                auctionTotalDonationVo.getAuctionUuid()).orElseThrow(
                 () -> new CustomException(ResponseStatus.NO_DATA)
         );
         try {
@@ -397,7 +399,7 @@ public class AuctionPostServiceImpl implements AuctionPostService {
                             .auctionEndTime(auctionPost.getAuctionEndTime())
                             .startPrice(auctionPost.getStartPrice())
                             .incrementUnit(auctionPost.getIncrementUnit())
-                            .totalDonation(updateTotalDonationUpdateVo.getTotalDonationAmount())
+                            .totalDonation(auctionTotalDonationVo.getDonation())
                             .state(auctionPost.getState())
                             .build()
             );
@@ -452,5 +454,41 @@ public class AuctionPostServiceImpl implements AuctionPostService {
                 .forEach(mainPagePostResponseVoList::add);
 
         return mainPagePostResponseVoList;
+    }
+
+    @Override
+    public EventStartTimeDto updateStateByAuctionUuid(String auctionUuid, AuctionStateEnum state)  {
+        Optional<CommandAuctionPost> commandAuctionPostOpt = commandAuctionPostRepository.findByAuctionUuid(auctionUuid);
+
+        if (commandAuctionPostOpt.isPresent()) {
+            CommandAuctionPost auctionPost = commandAuctionPostOpt.get();
+            commandAuctionPostRepository.save(
+                CommandAuctionPost.builder()
+                    .auctionPostId(auctionPost.getAuctionPostId())
+                    .auctionUuid(auctionPost.getAuctionUuid())
+                    .adminUuid(auctionPost.getAdminUuid())
+                    .influencerUuid(auctionPost.getInfluencerUuid())
+                    .influencerName(auctionPost.getInfluencerName())
+                    .title(auctionPost.getTitle())
+                    .content(auctionPost.getContent())
+                    .numberOfEventParticipants(auctionPost.getNumberOfEventParticipants())
+                    .localName(auctionPost.getLocalName())
+                    .eventPlace(auctionPost.getEventPlace())
+                    .eventStartTime(auctionPost.getEventStartTime())
+                    .eventCloseTime(auctionPost.getEventCloseTime())
+                    .auctionStartTime(auctionPost.getAuctionStartTime())
+                    .auctionEndTime(auctionPost.getAuctionEndTime())
+                    .startPrice(auctionPost.getStartPrice())
+                    .incrementUnit(auctionPost.getIncrementUnit())
+                    .totalDonation(auctionPost.getTotalDonation())
+                    .state(state)
+                    .build()
+            );
+            return EventStartTimeDto.builder()
+                .auctionUuid(auctionUuid)
+                .eventStartTime(auctionPost.getEventStartTime())
+                .build();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/kafka/Topics.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/kafka/Topics.java
@@ -11,7 +11,9 @@ public enum Topics {
     AUCTION_POST_SERVICE(Constant.AUCTION_POST_SERVICE),
     PAYMENT_SERVICE(Constant.PAYMENT_SERVICE),
     INITIAL_AUCTION(Constant.INITIAL_AUCTION),
-    AUCTION_CLOSE(Constant.AUCTION_CLOSE);
+    AUCTION_CLOSE(Constant.AUCTION_CLOSE),
+    AUCTION_POST_DONATION_UPDATE(Constant.AUCTION_POST_DONATION_UPDATE),
+    EVENT_START_TOPIC(Constant.EVENT_START_TOPIC)
     ;
 
     public static class Constant {
@@ -22,6 +24,7 @@ public enum Topics {
         public static final String AUCTION_POST_DONATION_UPDATE = "auction-post-donation-update-topic";
         public static final String INITIAL_AUCTION = "initial-auction-topic";
         public static final String AUCTION_CLOSE = "auction-close-topic";
+        public static final String EVENT_START_TOPIC = "event-start-topic";
     }
 
     private final String topic;

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/kafka/dto/EventStartTimeDto.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/kafka/dto/EventStartTimeDto.java
@@ -1,0 +1,22 @@
+package com.skyhorsemanpower.BE_AuctionPost.kafka.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class EventStartTimeDto {
+
+    private String auctionUuid;
+    private long eventStartTime;
+
+    @Builder
+    public EventStartTimeDto(String auctionUuid, long eventStartTime) {
+        this.auctionUuid = auctionUuid;
+        this.eventStartTime = eventStartTime;
+    }
+}


### PR DESCRIPTION
- [x] #115 
- 기존 mongodb 도큐먼트(경매글)의 상태를 변경하는 로직을 postgresql 레코드(경매글)의 상태를 변경하도록 수정했습니다. 
- CDC를 적용했기 때문에 postgresql의 레코드를 수정하면 자동으로 mongodb가 변경사항을 반영합니다. 