### PR TITLE
refactor: 경매글 리스트 없는 경우, 예외처리가 아닌 빈 리스트 반환(#134)

### DIFF
--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImpl.java
@@ -136,12 +136,6 @@ public class AuctionPostServiceImpl implements AuctionPostService {
                 searchAllAuctionDto, PageRequest.of(page, size)
         );
 
-        // 조회 없는 경우 예외 처리
-        if (readAuctionPostPage.isEmpty()) {
-            log.info("Search Auction result is Empty");
-            throw new CustomException(ResponseStatus.NO_DATA);
-        }
-
         List<ReadAuctionPost> auctionPosts = readAuctionPostPage.getContent();
 
         // Vo에 들어가는 데이터로 변환
@@ -253,12 +247,6 @@ public class AuctionPostServiceImpl implements AuctionPostService {
         Page<ReadAuctionPost> readAuctionPostPage = readAuctionPostRepository.findAllInfluencerAuctionPost(
                 influencerAllAuctionPostDto, PageRequest.of(page, size)
         );
-
-        // 조회 없는 경우 예외 처리
-        if (readAuctionPostPage.isEmpty()) {
-            log.info("Search Influencer Auction result is Empty");
-            throw new CustomException(ResponseStatus.NO_DATA);
-        }
 
         List<ReadAuctionPost> auctionPosts = readAuctionPostPage.getContent();
 

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/impl/CustomReadAuctionPostRepositoryImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/repository/mongotemplate/impl/CustomReadAuctionPostRepositoryImpl.java
@@ -145,7 +145,8 @@ public class CustomReadAuctionPostRepositoryImpl implements CustomReadAuctionPos
     }
 
     @Override
-    public SearchAuctionPostTitleAndInfluencerNameResponseVo getAuctionPostTitleAndInfluencerName(SearchAuctionPostTitleDto searchAuctionPostTitleDto) {
+    public SearchAuctionPostTitleAndInfluencerNameResponseVo getAuctionPostTitleAndInfluencerName(
+            SearchAuctionPostTitleDto searchAuctionPostTitleDto) {
         log.info("SearchAuctionPostTitleDto >>> {}", searchAuctionPostTitleDto.toString());
 
         String searchData = searchAuctionPostTitleDto.getData();

--- a/src/test/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImplTest.java
+++ b/src/test/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/AuctionPostServiceImplTest.java
@@ -1,0 +1,68 @@
+package com.skyhorsemanpower.BE_AuctionPost.application.impl;
+
+import com.skyhorsemanpower.BE_AuctionPost.config.QuartzJobConfig;
+import com.skyhorsemanpower.BE_AuctionPost.data.dto.SearchAllAuctionPostDto;
+import com.skyhorsemanpower.BE_AuctionPost.domain.cqrs.read.ReadAuctionPost;
+import com.skyhorsemanpower.BE_AuctionPost.kafka.KafkaProducerCluster;
+import com.skyhorsemanpower.BE_AuctionPost.repository.AuctionImagesRepository;
+import com.skyhorsemanpower.BE_AuctionPost.repository.cqrs.command.CommandAuctionPostRepository;
+import com.skyhorsemanpower.BE_AuctionPost.repository.cqrs.read.ReadAuctionPostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class AuctionPostServiceImplTest {
+
+    private CommandAuctionPostRepository commandAuctionPostRepository;
+    private ReadAuctionPostRepository readAuctionPostRepository;
+    private AuctionImagesRepository auctionImagesRepository;
+    private QuartzJobConfig quartzJobConfig;
+    private KafkaProducerCluster producer;
+    private AuctionPostServiceImpl auctionPostService;
+    private SearchAllAuctionPostDto searchAllAuctionPostDto;
+
+    @BeforeEach
+    void setUp() {
+        commandAuctionPostRepository = Mockito.mock(CommandAuctionPostRepository.class);
+        readAuctionPostRepository = Mockito.mock(ReadAuctionPostRepository.class);
+        auctionImagesRepository = Mockito.mock(AuctionImagesRepository.class);
+        quartzJobConfig = Mockito.mock(QuartzJobConfig.class);
+        producer = Mockito.mock(KafkaProducerCluster.class);
+
+        auctionPostService = new AuctionPostServiceImpl(
+                commandAuctionPostRepository, readAuctionPostRepository, auctionImagesRepository, quartzJobConfig, producer);
+    }
+
+    @Test
+    @DisplayName("경매글 리스트 조회 결과가 빈 리스트인 경우 테스트")
+    void testSearchAllAuction_noAuctionPosts() {
+        // given
+        // 빈 페이지 객체 생성
+        Page<ReadAuctionPost> emptyPage = new PageImpl<>(Collections.emptyList(), PageRequest.of(0, 10), 0);
+
+        // when
+        when(readAuctionPostRepository.findAllAuctionPost(any(SearchAllAuctionPostDto.class), any(PageRequest.class)))
+                .thenReturn(emptyPage);
+        List<ReadAuctionPost> emptyAuctionPosts = emptyPage.getContent();
+
+        // then
+        assertTrue(emptyAuctionPosts.isEmpty(), "The auctionPosts list should be empty");
+
+        // 추가 검증
+        // auctionPosts의 길이가 0인 상황에서 for문을 돌렸을 때, 에러가 발생하면 안된다.
+        for (ReadAuctionPost readAuctionPost : emptyAuctionPosts) {
+            System.out.println("출력되면 안된다.");
+        }
+    }
+}


### PR DESCRIPTION
기존에는 경매글 리스트가 없는 경우, 예외를 반환했습니다.
예외가 아닌 빈 리스트 반환하도록 수정했습니다.

없는 값을 넣은 경우, 빈 리스트 반환
![image](https://github.com/SKY-HORSE-MAN-POWER/BE_AuctionPost/assets/128444378/41c0ba15-ba28-4dd8-a901-b1f5245eb923)
