### PR TITLE
Feature/#158

### DIFF
--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/InfluencerService.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/InfluencerService.java
@@ -21,4 +21,6 @@ public interface InfluencerService {
 	List<InfluencerSearchResponseDto> searchInfluencer(String name);
 
 	List<InfluencerSummaryDto> getInfluencerSummaries(InfluencerSummariesRequestDto influencerSummariesRequestDto);
+
+	List<InfluencerDetailResponseDto> getAllInfluencers();
 }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/InfluencerServiceImpl.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/InfluencerServiceImpl.java
@@ -135,4 +135,18 @@ public class InfluencerServiceImpl implements InfluencerService {
 					.build()
 			).toList();
 	}
+
+	@Override
+	public List<InfluencerDetailResponseDto> getAllInfluencers() {
+		List<Influencer> influencers = influencerRepository.findAll();
+        return influencers.stream()
+			.map(influencer -> InfluencerDetailResponseDto.builder()
+				.influencerUuid(influencer.getUuid())
+				.name(influencer.getName())
+				.profileImage(influencer.getProfileImage())
+				.birth(influencer.getBirthDate())
+				.description(influencer.getDescription())
+				.build())
+			.toList();
+	}
 }

--- a/src/main/java/com/skyhorsemanpower/BE_AuctionPost/presentation/InfluencerController.java
+++ b/src/main/java/com/skyhorsemanpower/BE_AuctionPost/presentation/InfluencerController.java
@@ -11,6 +11,7 @@ import com.skyhorsemanpower.BE_AuctionPost.data.vo.InfluencerAddRequestVo;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.InfluencerDetailResponseVo;
 import com.skyhorsemanpower.BE_AuctionPost.data.vo.InfluencerSearchResponseVo;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Slf4j
+@Tag(name = "인플루언서 서비스", description = "인플루언서 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/influencer")
 public class InfluencerController {
@@ -76,5 +78,11 @@ public class InfluencerController {
     ) {
         return new SuccessResponse<>(influencerService.getInfluencerSummaries(
             InfluencerSummariesRequestDto.queryParamToDto(influencerUuids)));
+    }
+
+    @GetMapping("/all")
+    @Operation(summary = "모든 인플루언서 조회", description = "등록된 모든 인플루언서를 조회해 리스트로 반환합니다.")
+    public SuccessResponse<List<InfluencerDetailResponseDto>> findAllInfluencers() {
+        return new SuccessResponse<>(influencerService.getAllInfluencers());
     }
 }

--- a/src/test/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/InfluencerTest.java
+++ b/src/test/java/com/skyhorsemanpower/BE_AuctionPost/application/impl/InfluencerTest.java
@@ -3,7 +3,9 @@ package com.skyhorsemanpower.BE_AuctionPost.application.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.skyhorsemanpower.BE_AuctionPost.GenerateRandom;
 import com.skyhorsemanpower.BE_AuctionPost.application.InfluencerService;
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.InfluencerDetailResponseDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.InfluencerSearchResponseDto;
@@ -130,5 +132,52 @@ public class InfluencerTest {
             assertThat(influencerSummaryDto.getDescription()).isEqualTo(
                 influencers.get(i).getDescription());
         }
+    }
+
+    @Test
+    @DisplayName("모든 인플루언서를 조회할때 1명 이상있으면 리스트에 담아 반환한다.")
+    void getAllInfluencersAtLeastOneTest() {
+        List<Influencer> influencers = List.of(
+            Influencer.builder()
+                .uuid(GenerateRandom.influencerUuid())
+                .name("아이유")
+                .profileImage("https://iu.png")
+                .birthDate(LocalDate.of(1993, 5, 16))
+                .description("국힙원탑")
+                .build(),
+            Influencer.builder()
+                .uuid(GenerateRandom.influencerUuid())
+                .name("장원영")
+                .profileImage("https://jwy.png")
+                .birthDate(LocalDate.of(2004, 8, 31))
+                .description("공주님")
+                .build()
+        );
+
+        Mockito.when(influencerRepository.findAll()).thenReturn(influencers);
+
+        List<InfluencerDetailResponseDto> influencerDetailResponseDtos = influencerService.getAllInfluencers();
+
+        assertThat(influencerDetailResponseDtos.size()).isEqualTo(influencers.size());
+        for (int i = 0; i < influencerDetailResponseDtos.size(); i++) {
+            assertThat(influencerDetailResponseDtos.get(i).getInfluencerUuid()).isEqualTo(influencers.get(i).getUuid());
+            assertThat(influencerDetailResponseDtos.get(i).getName()).isEqualTo(influencers.get(i).getName());
+            assertThat(influencerDetailResponseDtos.get(i).getProfileImage()).isEqualTo(
+                influencers.get(i).getProfileImage());
+            assertThat(influencerDetailResponseDtos.get(i).getBirth()).isEqualTo(influencers.get(i).getBirthDate());
+            assertThat(influencerDetailResponseDtos.get(i).getDescription()).isEqualTo(influencers.get(i).getDescription());
+        }
+    }
+
+    @Test
+    @DisplayName("모든 인플루언서를 조회할때 등록된 인플루언서가 없으면 빈 리스트를 반환한다.")
+    void getAllInfluencersEmptyListTest() {
+        List<Influencer> influencers = List.of();
+
+        Mockito.when(influencerRepository.findAll()).thenReturn(influencers);
+
+        List<InfluencerDetailResponseDto> influencerDetailResponseDtos = influencerService.getAllInfluencers();
+
+        assertTrue(influencerDetailResponseDtos.isEmpty());
     }
 }

--- a/src/test/java/com/skyhorsemanpower/BE_AuctionPost/presentation/InfluencerControllerTest.java
+++ b/src/test/java/com/skyhorsemanpower/BE_AuctionPost/presentation/InfluencerControllerTest.java
@@ -1,12 +1,15 @@
 package com.skyhorsemanpower.BE_AuctionPost.presentation;
 
+import static com.mongodb.assertions.Assertions.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.skyhorsemanpower.BE_AuctionPost.GenerateRandom;
 import com.skyhorsemanpower.BE_AuctionPost.application.InfluencerService;
+import com.skyhorsemanpower.BE_AuctionPost.data.dto.InfluencerDetailResponseDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.InfluencerSummariesRequestDto;
 import com.skyhorsemanpower.BE_AuctionPost.data.dto.InfluencerSummaryDto;
 import com.skyhorsemanpower.BE_AuctionPost.repository.cqrs.command.InfluencerRepository;
@@ -19,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -90,5 +94,43 @@ class InfluencerControllerTest {
             assertThat(actual.getBirthDate()).isEqualTo(expected.getBirthDate());
             assertThat(actual.getDescription()).isEqualTo(expected.getDescription());
         }
+    }
+
+    @Test
+    @DisplayName("인플루언서 uuid리스트로 조회 요청시 인플루언서 정보가 담긴 리스트를 반환한다.")
+    void findAllInfluencersTest() throws Exception {
+        List<InfluencerDetailResponseDto> influencerDetailResponseDtos = List.of(
+            InfluencerDetailResponseDto.builder()
+                .influencerUuid(GenerateRandom.influencerUuid())
+                .name("아이유")
+                .profileImage("https://iu.png")
+                .birth(LocalDate.of(1993, 5, 16))
+                .description("국힙원탑")
+                .build(),
+            InfluencerDetailResponseDto.builder()
+                .influencerUuid(GenerateRandom.influencerUuid())
+                .name("장원영")
+                .profileImage("https://jwy.png")
+                .birth(LocalDate.of(2004, 8, 31))
+                .description("공주님")
+                .build()
+        );
+
+        Mockito.when(influencerService.getAllInfluencers()).thenReturn(influencerDetailResponseDtos);
+
+        MvcResult result = mockMvc.perform(get("/api/v1/influencer/all" )
+                .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        String responseContent = response.getContentAsString();
+
+        assertTrue(responseContent.contains("\"influencerUuid\""));
+        assertTrue(responseContent.contains("\"name\""));
+        assertTrue(responseContent.contains("\"profileImage\""));
+        assertTrue(responseContent.contains("\"birth\""));
+        assertTrue(responseContent.contains("\"description\""));
     }
 }


### PR DESCRIPTION
- [x] #158 
- 전체 인플루언서를 조회하는 API를 구현했습니다.
- 서비스 레이어 로직에서 `parallelStream`을 사용하려했으나, 여러 스레드를 사용하면 경매글 조회에 부담이 있을것 같아 `stream`을 사용했습니다.